### PR TITLE
Implement notification message construction

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -33,6 +33,12 @@
      - Armar e desarmar alarmes
      - Consulta de status `/controls/{alarm_id}/status`
 
+  5. **notification-service** (porta 8004)
+     - Envia notificacoes para usuarios
+     - `/health`, `/notify`
+     - Mensagem da notificação é construída automaticamente pelo serviço
+
+
 - **Gateway (opcional):**  
   - Proxy REST que encaminha `/users` e `/alarms` entre frontends e microserviços.
 
@@ -79,13 +85,19 @@ sistemaAntifurtoAPI/
 │   ├── models/
 │   │   └── alarm.go
 │   └── main.go
-└── control-service/
+├── control-service/
     ├── handlers/
     │   ├── controlHandler.go
     │   ├── database.go
     │   └── middlewares.go
     ├── models/
     │   └── control.go
+└── notification-service/
+    ├── handlers/
+    │   ├── database.go
+    │   └── notify_handler.go
+    ├── models/
+    │   └── notification.go
     └── main.go
 
 

--- a/README.md
+++ b/README.md
@@ -67,6 +67,8 @@
 | POST   | `/triggers`                        | Registra um disparo de alarme     |
 | GET    | `/alarms/{alarm_id}/triggers`      | Lista disparos de um alarme       |
 
+Disparos geram notificações via **notification-service** para todos os usuários autorizados.
+
 ## Regras de negócio adicionadas
 - `event` deve ser `open` ou `presence`.
 - `alarm_id` e `point` devem existir no alarm-service.
@@ -86,6 +88,7 @@
 | POST   | `/controls/{alarm_id}/disarm` | Desarma o alarme indicado             |
 | GET    | `/controls/{alarm_id}/status` | Consulta o estado atual do alarme     |
 | GET    | `/health`                     | Verifica se o serviço está OK         |
+Ao armar ou desarmar com sucesso, o serviço envia uma notificação via **notification-service** para o usuário informado.
 
 ## Exemplo de corpo para arm/disarm
 

--- a/README.md
+++ b/README.md
@@ -95,3 +95,33 @@
   "mode": "app"
 }
 ```
+
+---
+
+# Documentação — **notification-service**
+
+> Micro-serviço em **Go + Gin** responsável por enviar notificações aos usuários.
+> Porta padrão: **http://localhost:8004**
+
+## Sumário
+| Método | Rota      | Descrição                         |
+| ------ | --------- | --------------------------------- |
+| GET    | `/health` | Verifica se o serviço está OK     |
+| POST   | `/notify` | Envia uma notificação ao usuário   |
+
+## Exemplo de corpo para `/notify`
+
+```json
+{
+  "user_id": 1,
+  "alarm_id": 2,
+  "event": "arm",
+  "timestamp": "2025-06-06T15:00:00Z"
+}
+```
+
+Mensagem gerada:
+
+```
+O Alarme de número 2 foi ativado (06/06/2025 - 15:00)
+```

--- a/control-service/handlers/controlHandler.go
+++ b/control-service/handlers/controlHandler.go
@@ -14,6 +14,8 @@ import (
 	"github.com/gin-gonic/gin"
 )
 
+const notificationServiceURL = "http://localhost:8004/notify"
+
 // ControlRequest representa o body para armar/desarmar
 type ControlRequest struct {
 	UserID *int64 `json:"user_id,omitempty"`
@@ -174,14 +176,14 @@ func sendLog(ctrl models.Control) {
 }
 
 func sendNotification(ctrl models.Control) {
-	if ctrl.Result != "success" {
+	if ctrl.Result != "success" || ctrl.UserID == nil {
 		return
 	}
 	payload, _ := json.Marshal(gin.H{
+		"user_id":   *ctrl.UserID,
 		"alarm_id":  ctrl.AlarmID,
-		"action":    ctrl.Action,
-		"mode":      ctrl.Mode,
+		"event":     ctrl.Action,
 		"timestamp": ctrl.Timestamp,
 	})
-	http.Post("http://localhost:8005/notify", "application/json", bytes.NewBuffer(payload))
+	http.Post(notificationServiceURL, "application/json", bytes.NewBuffer(payload))
 }

--- a/notification-service/handlers/database.go
+++ b/notification-service/handlers/database.go
@@ -1,0 +1,4 @@
+package handlers
+
+// InitDatabase não faz nada pois o notification-service é stateless.
+func InitDatabase() {}

--- a/notification-service/handlers/notify_handler.go
+++ b/notification-service/handlers/notify_handler.go
@@ -1,0 +1,119 @@
+package handlers
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"log"
+	"net/http"
+	"time"
+
+	"github.com/bastosanaa/sistemaAntifurtoAPI/notification-service/models"
+	"github.com/gin-gonic/gin"
+)
+
+const (
+	userServiceURL    = "http://localhost:8001"
+	loggingServiceURL = "http://localhost:8004/logs"
+)
+
+// Health responde ao GET /health.
+func Health(c *gin.Context) {
+	c.JSON(http.StatusOK, gin.H{"status": "notification-service OK"})
+}
+
+// Notify trata POST /notify e simula o envio de uma notificação.
+func Notify(c *gin.Context) {
+	var input struct {
+		UserID    int64  `json:"user_id"`
+		AlarmID   int64  `json:"alarm_id"`
+		Event     string `json:"event"`
+		Timestamp string `json:"timestamp"`
+	}
+	if err := c.ShouldBindJSON(&input); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		return
+	}
+
+	if input.Event != "arm" && input.Event != "disarm" && input.Event != "trigger" {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "event inválido"})
+		return
+	}
+	t, err := time.Parse(time.RFC3339, input.Timestamp)
+	if err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "timestamp inválido"})
+		return
+	}
+
+	phone, statusCode, err := fetchPhone(input.UserID)
+	if err != nil {
+		if statusCode == http.StatusBadGateway {
+			c.JSON(http.StatusBadGateway, gin.H{"error": "falha ao chamar user-service"})
+			return
+		}
+		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+		return
+	}
+	if statusCode == http.StatusNotFound {
+		c.JSON(http.StatusNotFound, gin.H{"error": "Usuário não encontrado"})
+		return
+	}
+
+	msg := formatMessage(input.AlarmID, input.Event, t)
+	log.Printf("[NOTIFY] Para: %s | Alarme: %d | Evento: %s | Mensagem: %s", phone, input.AlarmID, input.Event, msg)
+
+	not := models.Notification{
+		UserID:    input.UserID,
+		AlarmID:   input.AlarmID,
+		Event:     input.Event,
+		Message:   msg,
+		Timestamp: t,
+	}
+	sendLog(not)
+
+	c.JSON(http.StatusOK, gin.H{"sent": true})
+}
+
+func fetchPhone(id int64) (string, int, error) {
+	resp, err := http.Get(fmt.Sprintf("%s/users/%d", userServiceURL, id))
+	if err != nil {
+		return "", http.StatusBadGateway, err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode == http.StatusNotFound {
+		return "", http.StatusNotFound, nil
+	}
+	if resp.StatusCode != http.StatusOK {
+		return "", http.StatusBadGateway, fmt.Errorf("user-service status %d", resp.StatusCode)
+	}
+	var data struct {
+		Phone string `json:"phone"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&data); err != nil {
+		return "", http.StatusInternalServerError, err
+	}
+	return data.Phone, http.StatusOK, nil
+}
+
+func sendLog(n models.Notification) {
+	body, err := json.Marshal(n)
+	if err != nil {
+		return
+	}
+	http.Post(loggingServiceURL, "application/json", bytes.NewBuffer(body))
+}
+
+func formatMessage(alarmID int64, event string, t time.Time) string {
+	var action string
+	switch event {
+	case "arm":
+		action = "ativado"
+	case "disarm":
+		action = "desativado"
+	case "trigger":
+		action = "disparado"
+	default:
+		action = event
+	}
+	return fmt.Sprintf("O Alarme de número %d foi %s (%s)", alarmID, action, t.Format("02/01/2006 - 15:04"))
+}

--- a/notification-service/main.go
+++ b/notification-service/main.go
@@ -1,0 +1,17 @@
+package main
+
+import (
+	"github.com/bastosanaa/sistemaAntifurtoAPI/notification-service/handlers"
+	"github.com/gin-gonic/gin"
+)
+
+func main() {
+	handlers.InitDatabase()
+
+	r := gin.Default()
+
+	r.GET("/health", handlers.Health)
+	r.POST("/notify", handlers.Notify)
+
+	r.Run(":8004")
+}

--- a/notification-service/models/notification.go
+++ b/notification-service/models/notification.go
@@ -1,0 +1,12 @@
+package models
+
+import "time"
+
+// Notification representa uma notificação enviada ao usuário.
+type Notification struct {
+	UserID    int64     `json:"user_id"`
+	AlarmID   int64     `json:"alarm_id"`
+	Event     string    `json:"event"`
+	Message   string    `json:"message"`
+	Timestamp time.Time `json:"timestamp"`
+}


### PR DESCRIPTION
## Summary
- adjust `notification-service` to generate notification messages from request data
- document generated message in README example
- note message generation rule in AGENTS guidelines

## Testing
- `go build ./...` *(fails: Forbidden download)*

------
https://chatgpt.com/codex/tasks/task_e_6845f0cec3048327810c6f6ce2190696