### PR TITLE
Implement logging-service and update services

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -29,7 +29,7 @@
      - `/triggers`, `/alarms/{id}/triggers`
      - Chama `logging-service` e `notification-service`
 
-  4. **control-service** (porta 8003)
+  4. **control-service** (porta 8005)
      - Armar e desarmar alarmes
      - Consulta de status `/controls/{alarm_id}/status`
 
@@ -37,6 +37,10 @@
      - Envia notificacoes para usuarios
      - `/health`, `/notify`
      - Mensagem da notificação é construída automaticamente pelo serviço
+
+  6. **logging-service** (porta 8006)
+     - Centraliza todos os logs de arm/disarm/trigger
+     - `/health`, `/logs`
 
 
 - **Gateway (opcional):**  
@@ -51,27 +55,6 @@ sistemaAntifurtoAPI/
 ├── gateway/
 │   └── main.go
 ├── user-service/
-
-│ ├── handlers/
-│ │ ├── database.go
-│ │ └── userHandler.go
-│ ├── models/
-│ │ └── user.go
-│ └── main.go
-├── alarm-service/
-│ ├── handlers/
-│ │ ├── database.go
-│ │ └── alarmHandler.go
-│ ├── models/
-│ │ └── alarm.go
-│ └── main.go
-└── trigger-service/
-    ├── handlers/
-    │ ├── database.go
-    │ └── trigger_handler.go
-    ├── models/
-    │ └── trigger.go
-
 │   ├── handlers/
 │   │   ├── database.go
 │   │   └── userHandler.go
@@ -85,19 +68,34 @@ sistemaAntifurtoAPI/
 │   ├── models/
 │   │   └── alarm.go
 │   └── main.go
+├── trigger-service/
+│   ├── handlers/
+│   │   ├── database.go
+│   │   └── trigger_handler.go
+│   ├── models/
+│   │   └── trigger.go
+│   └── main.go
 ├── control-service/
+│   ├── handlers/
+│   │   ├── controlHandler.go
+│   │   ├── database.go
+│   │   └── middlewares.go
+│   ├── models/
+│   │   └── control.go
+│   └── main.go
+├── notification-service/
+│   ├── handlers/
+│   │   ├── database.go
+│   │   └── notify_handler.go
+│   ├── models/
+│   │   └── notification.go
+│   └── main.go
+└── logging-service/
     ├── handlers/
-    │   ├── controlHandler.go
     │   ├── database.go
-    │   └── middlewares.go
+    │   └── log_handler.go
     ├── models/
-    │   └── control.go
-└── notification-service/
-    ├── handlers/
-    │   ├── database.go
-    │   └── notify_handler.go
-    ├── models/
-    │   └── notification.go
+    │   └── log.go
     └── main.go
 
 

--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@
 # Documentação — **trigger-service**
 
 > Micro-serviço em **Go + Gin** responsável por registrar disparos de alarmes.
+> Porta padrão: **http://localhost:8003**
 
 
 ---
@@ -79,7 +80,7 @@ Disparos geram notificações via **notification-service** para todos os usuári
 # Documentação — **control-service**
 
 > Micro-serviço em **Go + Gin** responsável por armar e desarmar alarmes.
-> Porta padrão: **http://localhost:8003**
+> Porta padrão: **http://localhost:8005**
 
 
 | Método | Rota                           | Descrição                             |
@@ -127,4 +128,30 @@ Mensagem gerada:
 
 ```
 O Alarme de número 2 foi ativado (06/06/2025 - 15:00)
+```
+
+---
+
+# Documentação — **logging-service**
+
+> Micro-serviço em **Go + Gin** responsável por registrar todos os eventos de arm, disarm e trigger.
+> Porta padrão: **http://localhost:8006**
+
+## Sumário
+| Método | Rota      | Descrição                         |
+| ------ | --------- | --------------------------------- |
+| GET    | `/health` | Verifica se o serviço está OK     |
+| POST   | `/logs`   | Registra um evento de alarme      |
+
+## Exemplo de corpo para `/logs`
+
+```json
+{
+  "service": "control",
+  "alarm_id": 1,
+  "user_id": 2,
+  "action": "arm",
+  "mode": "app",
+  "timestamp": "2025-06-08T14:30:00Z"
+}
 ```

--- a/control-service/handlers/controlHandler.go
+++ b/control-service/handlers/controlHandler.go
@@ -170,9 +170,8 @@ func sendLog(ctrl models.Control) {
 		"action":    ctrl.Action,
 		"mode":      ctrl.Mode,
 		"timestamp": ctrl.Timestamp,
-		"result":    ctrl.Result,
 	})
-	http.Post("http://localhost:8004/logs", "application/json", bytes.NewBuffer(payload))
+	http.Post("http://localhost:8006/logs", "application/json", bytes.NewBuffer(payload))
 }
 
 func sendNotification(ctrl models.Control) {

--- a/control-service/main.go
+++ b/control-service/main.go
@@ -17,5 +17,5 @@ func main() {
 	r.GET("/controls/:id/status", handlers.GetStatus)
 	r.GET("/health", handlers.Health)
 
-	r.Run(":8003")
+	r.Run(":8005")
 }

--- a/logging-service/handlers/database.go
+++ b/logging-service/handlers/database.go
@@ -1,0 +1,37 @@
+package handlers
+
+import (
+	"database/sql"
+	"log"
+
+	_ "github.com/mattn/go-sqlite3"
+)
+
+var DB *sql.DB
+
+// InitDatabase abre ou cria logs.db e cria a tabela logs.
+func InitDatabase() {
+	var err error
+	DB, err = sql.Open("sqlite3", "./logs.db")
+	if err != nil {
+		log.Fatalf("Falha ao abrir banco de dados: %v", err)
+	}
+
+	createTable := `
+    CREATE TABLE IF NOT EXISTS logs (
+        id INTEGER PRIMARY KEY AUTOINCREMENT,
+        service TEXT NOT NULL,
+        alarm_id INTEGER NOT NULL,
+        user_id INTEGER,
+        action TEXT NOT NULL,
+        mode TEXT,
+        point TEXT,
+        timestamp DATETIME NOT NULL
+    );`
+
+	if _, err := DB.Exec(createTable); err != nil {
+		log.Fatalf("Erro ao criar tabela logs: %v", err)
+	}
+
+	log.Println("Banco logs.db inicializado e tabela 'logs' verificada.")
+}

--- a/logging-service/handlers/log_handler.go
+++ b/logging-service/handlers/log_handler.go
@@ -1,0 +1,68 @@
+package handlers
+
+import (
+	"net/http"
+	"time"
+
+	"github.com/bastosanaa/sistemaAntifurtoAPI/logging-service/models"
+	"github.com/gin-gonic/gin"
+)
+
+// CreateLog trata POST /logs e registra um novo evento.
+func CreateLog(c *gin.Context) {
+	var input struct {
+		Service   string  `json:"service"`
+		AlarmID   int64   `json:"alarm_id"`
+		UserID    *int64  `json:"user_id"`
+		Action    string  `json:"action"`
+		Mode      *string `json:"mode"`
+		Point     *string `json:"point"`
+		Timestamp string  `json:"timestamp"`
+	}
+	if err := c.ShouldBindJSON(&input); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		return
+	}
+
+	if input.Service != "control" && input.Service != "trigger" {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "service inválido"})
+		return
+	}
+
+	if input.Action != "arm" && input.Action != "disarm" && input.Action != "trigger" {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "action inválido"})
+		return
+	}
+
+	ts, err := time.Parse(time.RFC3339, input.Timestamp)
+	if err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "timestamp inválido"})
+		return
+	}
+
+	res, err := DB.Exec(`INSERT INTO logs (service, alarm_id, user_id, action, mode, point, timestamp)
+        VALUES (?, ?, ?, ?, ?, ?, ?)`,
+		input.Service, input.AlarmID, input.UserID, input.Action, input.Mode, input.Point, ts)
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+		return
+	}
+	id, _ := res.LastInsertId()
+
+	entry := models.LogEntry{
+		ID:        id,
+		Service:   input.Service,
+		AlarmID:   input.AlarmID,
+		UserID:    input.UserID,
+		Action:    input.Action,
+		Mode:      input.Mode,
+		Point:     input.Point,
+		Timestamp: ts,
+	}
+	c.JSON(http.StatusCreated, entry)
+}
+
+// Health responde ao GET /health.
+func Health(c *gin.Context) {
+	c.JSON(http.StatusOK, gin.H{"status": "logging-service OK"})
+}

--- a/logging-service/main.go
+++ b/logging-service/main.go
@@ -1,0 +1,17 @@
+package main
+
+import (
+	"github.com/bastosanaa/sistemaAntifurtoAPI/logging-service/handlers"
+	"github.com/gin-gonic/gin"
+)
+
+func main() {
+	handlers.InitDatabase()
+	defer handlers.DB.Close()
+
+	r := gin.Default()
+	r.POST("/logs", handlers.CreateLog)
+	r.GET("/health", handlers.Health)
+
+	r.Run(":8006")
+}

--- a/logging-service/models/log.go
+++ b/logging-service/models/log.go
@@ -1,0 +1,15 @@
+package models
+
+import "time"
+
+// LogEntry representa um evento de armacao, desarmacao ou disparo registrado.
+type LogEntry struct {
+	ID        int64     `json:"id"`
+	Service   string    `json:"service"`
+	AlarmID   int64     `json:"alarm_id"`
+	UserID    *int64    `json:"user_id,omitempty"`
+	Action    string    `json:"action"`
+	Mode      *string   `json:"mode,omitempty"`
+	Point     *string   `json:"point,omitempty"`
+	Timestamp time.Time `json:"timestamp"`
+}

--- a/notification-service/handlers/notify_handler.go
+++ b/notification-service/handlers/notify_handler.go
@@ -14,7 +14,7 @@ import (
 
 const (
 	userServiceURL    = "http://localhost:8001"
-	loggingServiceURL = "http://localhost:8004/logs"
+	loggingServiceURL = "http://localhost:8006/logs"
 )
 
 // Health responde ao GET /health.

--- a/trigger-service/handlers/trigger_handler.go
+++ b/trigger-service/handlers/trigger_handler.go
@@ -14,7 +14,7 @@ import (
 
 const (
 	alarmServiceURL        = "http://localhost:8002"
-	loggingServiceURL      = "http://localhost:8004/logs"
+	loggingServiceURL      = "http://localhost:8006/logs"
 	notificationServiceURL = "http://localhost:8004/notify"
 )
 
@@ -102,7 +102,7 @@ func CreateTrigger(c *gin.Context) {
 		"service":   "trigger",
 		"alarm_id":  input.AlarmID,
 		"point":     input.Point,
-		"event":     input.Event,
+		"action":    "trigger",
 		"timestamp": timestamp,
 	}
 	body, _ := json.Marshal(payload)


### PR DESCRIPTION
## Summary
- add new logging-service with SQLite storage for log events
- send control/trigger/notification events to the new service
- document logging-service and update project docs
- fix port conflict by running control-service on port 8005

## Testing
- `go build ./...` *(fails: forbidden to download modules)*

------
https://chatgpt.com/codex/tasks/task_e_6845fc7dbcd88327ace977fff44314c9